### PR TITLE
Density matrix: discards and qubit creation

### DIFF
--- a/qujax/circuit.py
+++ b/qujax/circuit.py
@@ -43,7 +43,8 @@ def apply_gate(statetensor: jnp.ndarray, gate_unitary: jnp.ndarray, qubit_inds: 
 def _to_gate_funcs(gate_seq: Sequence[Union[str,
                                             jnp.ndarray,
                                             Callable[[jnp.ndarray], jnp.ndarray],
-                                            Callable[[], jnp.ndarray]]])\
+                                            Callable[[], jnp.ndarray]]],
+                   ignore: tuple[str, ...] = ())\
         -> Sequence[Callable[[jnp.ndarray], jnp.ndarray]]:
     """
     Ensures all gate_seq elements are functions that map (possibly empty) parameters
@@ -64,6 +65,10 @@ def _to_gate_funcs(gate_seq: Sequence[Union[str,
 
     gate_seq_callable = []
     for gate in gate_seq:
+        if gate in ignore:
+            gate_seq_callable.append(gate)
+            continue
+
         if isinstance(gate, str):
             gate = gates.__dict__[gate]
 

--- a/qujax/circuit_tools.py
+++ b/qujax/circuit_tools.py
@@ -41,7 +41,8 @@ def check_circuit(gate_seq: Sequence[Union[str,
                                            Callable[[], jnp.ndarray]]],
                   qubit_inds_seq: Sequence[Sequence[int]],
                   param_inds_seq: Sequence[Sequence[int]],
-                  n_qubits: int = None):
+                  n_qubits: int = None,
+                  additional_operations: tuple[str, ...] = ()):
     """
     Basic checks that circuit arguments conform.
 
@@ -72,11 +73,14 @@ def check_circuit(gate_seq: Sequence[Union[str,
         raise TypeError(f'gate_seq ({len(gate_seq)}), qubit_inds_seq ({len(qubit_inds_seq)})'
                         f'and param_inds_seq ({len(param_inds_seq)}) must have matching lengths')
 
-    if n_qubits is not None and n_qubits < max([max(qi) for qi in qubit_inds_seq]) + 1:
+    if (n_qubits is not None and
+       "create" not in additional_operations and
+        n_qubits < max([max(qi) for qi in qubit_inds_seq]) + 1):
         raise TypeError('n_qubits must be larger than largest qubit index in qubit_inds_seq')
 
     for g in gate_seq:
-        check_unitary(g)
+        if g not in additional_operations:
+            check_unitary(g)
 
 
 def _get_gate_str(gate_obj: Union[str,

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -50,3 +50,69 @@ def test_params_to_densitytensor_func():
     dt = params_to_dt(params)
 
     assert jnp.allclose(dt, dt_test)
+
+
+def test_discards():
+    n_qubits = 3
+
+    gate_seq = ["Rx" for _ in range(n_qubits)]
+    qubit_inds_seq = [(i,) for i in range(n_qubits)]
+    param_inds_seq = [(i,) for i in range(n_qubits)]
+
+    gate_seq += ["CZ" for _ in range(n_qubits - 1)]
+    qubit_inds_seq += [(i, i+1) for i in range(n_qubits - 1)]
+    param_inds_seq += [() for _ in range(n_qubits - 1)]
+
+    params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
+
+    gate_seq.append("discard")
+    qubits_to_discard = (1, 2,)
+    qubit_inds_seq.append(qubits_to_discard)
+    param_inds_seq.append(())
+
+    params_to_dt_w_discard = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
+
+    params = jnp.arange(1, n_qubits+1)/10.
+
+    dt = params_to_dt(params)
+    
+    dt_discard_test = dt
+    for n, q in enumerate(reversed(qubits_to_discard)):
+        dt_discard_test = jnp.trace(dt_discard_test, axis1=q, axis2=n_qubits + q - n)
+
+    dt_discard = params_to_dt_w_discard(params)
+
+    assert jnp.allclose(dt_discard, dt_discard_test)
+
+
+def test_creation():
+    statetensor = jnp.array([[1., 0.], [0., 0.]])
+    gate_seq = ["create", "create", "create"]
+    qubit_inds_seq = [(1,), (2,), (3,)]
+    params_inds_seq = [(0,), (0,), (0,)]
+
+    params = [statetensor]
+
+    params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, params_inds_seq, 1)
+
+    statetensor_test = jnp.zeros((2,) * 4 * 2)
+    statetensor_test = statetensor_test.at[(0,) * 4 * 2].set(1.)
+
+    dt = params_to_dt(params, statetensor)
+
+    assert jnp.allclose(dt, statetensor_test)
+
+
+def test_creating_and_discarding():
+    statetensor = jnp.array([[1., 0.], [0., 0.]])
+    gate_seq = ["create", "discard", "create", "discard"]
+    qubit_inds_seq = [(2,), (0,), (3,), (2,)]
+    params_inds_seq = [(0,), (), (0,), ()]
+
+    params = [statetensor]
+
+    params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, params_inds_seq, 1)
+
+    dt = params_to_dt(params, statetensor)
+
+    assert jnp.allclose(dt, statetensor)


### PR DESCRIPTION
Adds qubit discarding and qubit creation operations. See the corresponding test `test_creating_and_discarding` to get an idea how this is supposed to work; qubits are created using a `"create"` operation and discarded using a `discard` operation and indices are tracked internally.