### PR TITLE
Fix error when using double precision

### DIFF
--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -56,7 +56,7 @@ def kraus(densitytensor: jnp.ndarray,
         # ensure first dimensions indexes different kraus operators
 
     new_densitytensor, _ = scan(lambda dt, arr: (dt + _kraus_single(densitytensor, arr, qubit_inds), None),
-                                init=jnp.zeros_like(densitytensor, dtype='complex64'), xs=arrays)
+                                init=jnp.zeros_like(densitytensor, dtype='complex'), xs=arrays)
     # i.e. new_densitytensor = vmap(_kraus_single, in_axes=(None, 0, None))(densitytensor, arrays, qubit_inds).sum(0)
     return new_densitytensor
 

--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -56,7 +56,7 @@ def kraus(densitytensor: jnp.ndarray,
         # ensure first dimensions indexes different kraus operators
 
     new_densitytensor, _ = scan(lambda dt, arr: (dt + _kraus_single(densitytensor, arr, qubit_inds), None),
-                                init=jnp.zeros_like(densitytensor, dtype='complex'), xs=arrays)
+                                init=jnp.zeros_like(densitytensor) * 0.j, xs=arrays)
     # i.e. new_densitytensor = vmap(_kraus_single, in_axes=(None, 0, None))(densitytensor, arrays, qubit_inds).sum(0)
     return new_densitytensor
 


### PR DESCRIPTION
Changed the data type from `'complex64'` to `'complex'` in the initial density tensor in the `kraus` function because there is a data type mismatch when JAX is in double precision mode. By specifying only that it is complex the appropriate number of bits should be inferred from whatever is being used.