### PR TITLE
revamp expectation tests

### DIFF
--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -91,6 +91,7 @@ def _to_kraus_operator_seq_funcs(kraus_op: kraus_op_type,
         param_inds = [param_inds]
     return kraus_op_funcs, _arrayify_inds(param_inds)
 
+
 def partial_trace(densitytensor: jnp.ndarray,
                   indices_to_trace: Iterable[int]) -> jnp.ndarray:
     """
@@ -104,7 +105,7 @@ def partial_trace(densitytensor: jnp.ndarray,
     Returns:
         Resulting densitytensor on remaining qubits.
 
-    """                   
+    """
     n_qubits = densitytensor.ndim // 2
     einsum_indices = list(range(densitytensor.ndim))
     for i in indices_to_trace:

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -54,7 +54,7 @@ def test_bitstring_expectation():
     assert jnp.allclose(true_expectation_grad, expectation_grad_jit, atol=1e-5)
 
 
-def test_ZZ_X():
+def test_ZZ_Y():
     config.update("jax_enable_x64", True)  # Run this test with 64 bit precision
 
     n_qubits = 4


### PR DESCRIPTION
Tests now pass with 64 bit precision (indeed this is now also tested)

Also removed hard-coded values