### PR TITLE
Implement expectations for density matrices

### DIFF
--- a/qujax/__init__.py
+++ b/qujax/__init__.py
@@ -7,8 +7,11 @@ from qujax.circuit import apply_gate
 from qujax.circuit import get_params_to_statetensor_func
 
 from qujax.observable import statetensor_to_single_expectation
+from qujax.observable import densitytensor_to_single_expectation
 from qujax.observable import get_statetensor_to_expectation_func
 from qujax.observable import get_statetensor_to_sampled_expectation_func
+from qujax.observable import get_densitytensor_to_expectation_func
+from qujax.observable import get_densitytensor_to_sampled_expectation_func
 from qujax.observable import check_hermitian
 from qujax.observable import integers_to_bitstrings
 from qujax.observable import bitstrings_to_integers

--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -9,6 +9,22 @@ from qujax.circuit_tools import check_circuit
 
 kraus_op_type = Union[gate_type, Iterable[gate_type]]
 
+def statetensor_to_densitytensor(statetensor: jnp.ndarray) -> jnp.ndarray:
+    """
+    Computes a densitytensor representation of a pure quantum state
+    from its statetensor representaton
+
+    Args:
+        statetensor: Input statetensor.
+
+    Returns:
+        A densitytensor representing the quantum state.
+    """
+    n_qubits = statetensor.ndim
+    st = statetensor
+    dt = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2*n_qubits))
+    return dt
+
 
 def _kraus_single(densitytensor: jnp.ndarray,
                   array: jnp.ndarray,

--- a/qujax/observable.py
+++ b/qujax/observable.py
@@ -5,10 +5,34 @@ from jax import numpy as jnp, random
 from jax.lax import fori_loop
 
 from qujax.circuit import apply_gate
-from qujax.gates import I, X, Y, Z
+from qujax.gates import X, Y, Z
+from qujax.density_matrix import statetensor_to_densitytensor
 
-paulis = {'I': I, 'X': X, 'Y': Y, 'Z': Z}
+paulis = {'X': X, 'Y': Y, 'Z': Z}
 
+
+def densitytensor_to_single_expectation(densitytensor: jnp.ndarray,
+                                        hermitian: jnp.ndarray,
+                                        qubit_inds: Sequence[int]) -> float:
+    """
+    Evaluates expectation value of an observable represented by a Hermitian matrix (in tensor form).
+
+    Args:
+        densitytensor: Input densitytensor.
+        hermitian: Hermitian matrix representing observable
+            must be in tensor form with shape (2,2,...).
+        qubit_inds: Sequence of qubit indices for Hermitian matrix to be applied to.
+            Must have 2 * len(qubit_inds) == hermitian.ndim
+    Returns:
+        Expected value (float).
+    """
+    n_qubits = densitytensor.ndim // 2
+    dt_indices = 2 * list(range(n_qubits))
+    hermitian_indices = [i + densitytensor.ndim //2 for i in range(hermitian.ndim)]
+    for n, q in enumerate(qubit_inds):
+        dt_indices[q] = hermitian_indices[n + len(qubit_inds)]
+        dt_indices[q + n_qubits] = hermitian_indices[n]
+    return jnp.einsum(densitytensor, dt_indices, hermitian, hermitian_indices).real
 
 def statetensor_to_single_expectation(statetensor: jnp.ndarray,
                                       hermitian: jnp.ndarray,
@@ -20,8 +44,8 @@ def statetensor_to_single_expectation(statetensor: jnp.ndarray,
         statetensor: Input statetensor.
         hermitian: Hermitian array
             must be in tensor form with shape (2,2,...).
-        qubit_inds: Sequence of qubit indices for Hermitian to be applied to.
-            Must have 2 * len(qubit_inds) = hermitian.ndim
+        qubit_inds: Sequence of qubit indices for Hermitian matrix to be applied to.
+            Must have 2 * len(qubit_inds) == hermitian.ndim
 
     Returns:
         Expected value (float).
@@ -49,27 +73,7 @@ def check_hermitian(hermitian: Union[str, jnp.ndarray]):
             raise TypeError(f'Array not Hermitian: {hermitian}')
 
 
-def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
-                                        qubits_seq_seq: Sequence[Sequence[int]],
-                                        coefficients: Union[Sequence[float], jnp.ndarray]) \
-        -> Callable[[jnp.ndarray], float]:
-    """
-    Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
-   a list of coefficients and returns a function that converts a statetensor into an expected value.
-
-    Args:
-        hermitian_seq_seq: Sequence of sequences of Hermitian matrices/tensors.
-            Each Hermitian matrix is either represented by a tensor (jnp.ndarray) or by a list of 'X', 'Y' or 'Z' characters corresponding to the standard Pauli matrices.
-            E.g. [['Z', 'Z'], ['X']]
-        qubits_seq_seq: Sequence of sequences of integer qubit indices.
-            E.g. [[0,1], [2]]
-        coefficients: Sequence of float coefficients to scale the expected values.
-
-    Returns:
-        Function that takes statetensor and returns expected value (float).
-    """
-
-    def get_hermitian_tensor(hermitian_seq: Sequence[Union[str, jnp.ndarray]]) -> jnp.ndarray:
+def get_hermitian_tensor(hermitian_seq: Sequence[Union[str, jnp.ndarray]]) -> jnp.ndarray:
         """
         Convert a sequence of observables represented by Pauli strings or Hermitian matrices in tensor form into single array (in tensor form).
 
@@ -92,6 +96,31 @@ def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Uni
         full_mat = full_mat.reshape((2,) * int(jnp.log2(full_mat.size)))
         return full_mat
 
+
+def _get_tensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
+                                        qubits_seq_seq: Sequence[Sequence[int]],
+                                        coefficients: Union[Sequence[float], jnp.ndarray],
+                                        contraction_function: Callable) \
+        -> Callable[[jnp.ndarray], float]:
+    """
+    Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
+   a list of coefficients and returns a function that converts a tensor into an expected value.
+   The contraction function performs the tensor contraction according to the type of tensor provided
+   (i.e. whether it is a statetensor or a densitytensor).
+
+    Args:
+        hermitian_seq_seq: Sequence of sequences of Hermitian matrices/tensors.
+            Each Hermitian matrix is either represented by a tensor (jnp.ndarray) or by a list of 'X', 'Y' or 'Z' characters corresponding to the standard Pauli matrices.
+            E.g. [['Z', 'Z'], ['X']]
+        qubits_seq_seq: Sequence of sequences of integer qubit indices.
+            E.g. [[0,1], [2]]
+        coefficients: Sequence of float coefficients to scale the expected values.
+        contraction_function: Function that performs the tensor contraction.
+
+    Returns:
+        Function that takes tensor and returns expected value (float).
+    """
+
     hermitian_tensors = [get_hermitian_tensor(h_seq) for h_seq in hermitian_seq_seq]
 
     def statetensor_to_expectation_func(statetensor: jnp.ndarray) -> float:
@@ -107,11 +136,54 @@ def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Uni
         """
         out = 0
         for hermitian, qubit_inds, coeff in zip(hermitian_tensors, qubits_seq_seq, coefficients):
-            out += coeff * statetensor_to_single_expectation(statetensor, hermitian, qubit_inds)
+            out += coeff * contraction_function(statetensor, hermitian, qubit_inds)
         return out
 
     return statetensor_to_expectation_func
 
+def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
+                                        qubits_seq_seq: Sequence[Sequence[int]],
+                                        coefficients: Union[Sequence[float], jnp.ndarray]) \
+        -> Callable[[jnp.ndarray], float]:
+    """
+    Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
+   a list of coefficients and returns a function that converts a statetensor into an expected value.
+
+    Args:
+        hermitian_seq_seq: Sequence of sequences of Hermitian matrices/tensors.
+            Each Hermitian matrix is either represented by a tensor (jnp.ndarray) or by a list of 'X', 'Y' or 'Z' characters corresponding to the standard Pauli matrices.
+            E.g. [['Z', 'Z'], ['X']]
+        qubits_seq_seq: Sequence of sequences of integer qubit indices.
+            E.g. [[0,1], [2]]
+        coefficients: Sequence of float coefficients to scale the expected values.
+
+    Returns:
+        Function that takes statetensor and returns expected value (float).
+    """
+
+    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients, statetensor_to_single_expectation)
+
+def get_densitytensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
+                                        qubits_seq_seq: Sequence[Sequence[int]],
+                                        coefficients: Union[Sequence[float], jnp.ndarray]) \
+        -> Callable[[jnp.ndarray], float]:
+    """
+    Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
+   a list of coefficients and returns a function that converts a densitytensor into an expected value.
+
+    Args:
+        hermitian_seq_seq: Sequence of sequences of Hermitian matrices/tensors.
+            Each Hermitian matrix is either represented by a tensor (jnp.ndarray) or by a list of 'X', 'Y' or 'Z' characters corresponding to the standard Pauli matrices.
+            E.g. [['Z', 'Z'], ['X']]
+        qubits_seq_seq: Sequence of sequences of integer qubit indices.
+            E.g. [[0,1], [2]]
+        coefficients: Sequence of float coefficients to scale the expected values.
+
+    Returns:
+        Function that takes densitytensor and returns expected value (float).
+    """
+
+    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients, densitytensor_to_single_expectation)
 
 def get_statetensor_to_sampled_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
                                                 qubits_seq_seq: Sequence[Sequence[int]],
@@ -162,6 +234,57 @@ def get_statetensor_to_sampled_expectation_func(hermitian_seq_seq: Sequence[Sequ
         return statetensor_to_expectation_func(sampled_st)
 
     return statetensor_to_sampled_expectation_func
+
+
+def get_densitytensor_to_sampled_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
+                                                  qubits_seq_seq: Sequence[Sequence[int]],
+                                                  coefficients: Union[Sequence[float], jnp.ndarray]) \
+        -> Callable[[jnp.ndarray, random.PRNGKeyArray, int], float]:
+    """
+    Converts strings (or arrays) representing Hermitian matrices, qubit indices and
+    coefficients into a function that converts a densitytensor into a sampled expected value.
+
+    Args:
+        hermitian_seq_seq: Sequence of sequences of Hermitian matrices/tensors.
+            Each Hermitian is either a tensor (jnp.ndarray) or a string in ('X', 'Y', 'Z').
+            E.g. [['Z', 'Z'], ['X']]
+        qubits_seq_seq: Sequence of sequences of integer qubit indices.
+            E.g. [[0,1], [2]]
+        coefficients: Sequence of float coefficients to scale the expected values.
+
+    Returns:
+        Function that takes densitytensor, random key and integer number of shots
+        and returns sampled expected value (float).
+    """
+    densitytensor_to_expectation_func = get_densitytensor_to_expectation_func(hermitian_seq_seq,
+                                                                              qubits_seq_seq,
+                                                                              coefficients)
+
+    def densitytensor_to_sampled_expectation_func(statetensor: jnp.ndarray,
+                                                random_key: random.PRNGKeyArray,
+                                                n_samps: int) -> float:
+        """
+        Maps statetensor to sampled expected value.
+
+        Args:
+            statetensor: Input statetensor.
+            random_key: JAX random key
+            n_samps: Number of samples contributing to sampled expectation.
+
+        Returns:
+            Sampled expected value (float).
+
+        """
+        sampled_integers = sample_integers(random_key, statetensor, n_samps)
+        sampled_probs = fori_loop(0, n_samps,
+                                  lambda i, sv: sv.at[sampled_integers[i]].add(1),
+                                  jnp.zeros(statetensor.size))
+
+        sampled_probs /= n_samps
+        sampled_dt = statetensor_to_densitytensor(jnp.sqrt(sampled_probs).reshape(statetensor.shape))
+        return densitytensor_to_expectation_func(sampled_dt)
+
+    return densitytensor_to_sampled_expectation_func
 
 
 def integers_to_bitstrings(integers: Union[int, jnp.ndarray],

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -4,6 +4,7 @@ import qujax
 from qujax import _kraus_single, kraus, get_params_to_densitytensor_func
 from qujax import get_params_to_statetensor_func
 from qujax import partial_trace
+from qujax.density_matrix import statetensor_to_densitytensor
 
 
 def test_kraus_single():
@@ -121,7 +122,7 @@ def test_params_to_densitytensor_func():
     params = jnp.arange(n_qubits)/10.
 
     st = params_to_st(params)
-    dt_test = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2*n_qubits))
+    dt_test = statetensor_to_densitytensor(st)
 
     dt = params_to_dt(params)
 

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -1,6 +1,30 @@
 from jax import numpy as jnp, jit, grad, random, config
 import qujax
+from math import floor, ceil
 
+from qujax.observable import densitytensor_to_single_expectation, statetensor_to_single_expectation
+from qujax.density_matrix import statetensor_to_densitytensor
+
+from qujax.gates import Z
+   
+
+def test_single_expectation():
+    st1 = jnp.zeros((2,2,2))
+    st2 = jnp.zeros((2,2,2))
+    st1 = st1.at[(0,0,0)].set(1.)
+    st2 = st2.at[(1,0,0)].set(1.)
+    dt1 = statetensor_to_densitytensor(st1)
+    dt2 = statetensor_to_densitytensor(st2)
+    ZZ = jnp.kron(Z, Z).reshape(2,2,2,2)
+
+    est1 = statetensor_to_single_expectation(dt1, ZZ, [0, 1])
+    est2 = statetensor_to_single_expectation(dt2, ZZ, [0, 1])
+    edt1 = densitytensor_to_single_expectation(dt1, ZZ, [0, 1])
+    edt2 = densitytensor_to_single_expectation(dt2, ZZ, [0, 1])
+
+    assert est1.item() == edt1.item() == 1
+    assert est2.item() == edt2.item() == -1
+    
 
 def test_bitstring_expectation():
     n_qubits = 4
@@ -66,10 +90,14 @@ def test_ZZ_Y():
     st_to_exp = qujax.get_statetensor_to_expectation_func(hermitian_str_seq_seq,
                                                           qubit_inds_seq,
                                                           coefs)
+    dt_to_exp = qujax.get_statetensor_to_expectation_func(hermitian_str_seq_seq,
+                                                        qubit_inds_seq,
+                                                        coefs)
 
     state = random.uniform(random.PRNGKey(0), shape=(2 ** n_qubits,)) * 2
     state /= jnp.linalg.norm(state)
     st_in = state.reshape((2,) * n_qubits)
+    dt_in = statetensor_to_densitytensor(st_in)
 
     def big_hermitian_matrix(hermitian_str_seq, qubit_inds):
         qubit_arrs = [getattr(qujax.gates, s) for s in hermitian_str_seq]
@@ -97,22 +125,33 @@ def test_ZZ_Y():
     true_exp = jnp.dot(sv, sum_big_hs @ sv.conj()).real
 
     qujax_exp = st_to_exp(st_in)
+    qujax_dt_exp = dt_to_exp(dt_in)
     qujax_exp_jit = jit(st_to_exp)(st_in)
+    qujax_dt_exp_jit = jit(dt_to_exp)(dt_in)
 
     assert jnp.array(qujax_exp).shape == ()
     assert jnp.array(qujax_exp).dtype.name[:5] == 'float'
     assert jnp.isclose(true_exp, qujax_exp)
+    assert jnp.isclose(true_exp, qujax_dt_exp)
     assert jnp.isclose(true_exp, qujax_exp_jit)
+    assert jnp.isclose(true_exp, qujax_dt_exp_jit)
 
     st_to_samp_exp = qujax.get_statetensor_to_sampled_expectation_func(hermitian_str_seq_seq,
                                                                        qubit_inds_seq,
                                                                        coefs)
+    dt_to_samp_exp = qujax.get_statetensor_to_sampled_expectation_func(hermitian_str_seq_seq,
+                                                                    qubit_inds_seq,
+                                                                    coefs)
     qujax_samp_exp = st_to_samp_exp(st_in, random.PRNGKey(1), 1000000)
     qujax_samp_exp_jit = jit(st_to_samp_exp, static_argnums=2)(st_in, random.PRNGKey(2), 1000000)
+    qujax_samp_exp_dt = st_to_samp_exp(st_in, random.PRNGKey(1), 1000000)
+    qujax_samp_exp_dt_jit = jit(st_to_samp_exp, static_argnums=2)(st_in, random.PRNGKey(2), 1000000)
     assert jnp.array(qujax_samp_exp).shape == ()
     assert jnp.array(qujax_samp_exp).dtype.name[:5] == 'float'
     assert jnp.isclose(true_exp, qujax_samp_exp, rtol=1e-2)
     assert jnp.isclose(true_exp, qujax_samp_exp_jit, rtol=1e-2)
+    assert jnp.isclose(true_exp, qujax_samp_exp_dt, rtol=1e-2)
+    assert jnp.isclose(true_exp, qujax_samp_exp_dt_jit, rtol=1e-2)
 
 
 def test_sampling():


### PR DESCRIPTION
Implement expectations for density matrices:
- Add densitytensor_to_single_expectation
- Add get_densitytensor_to_expectation_func
- Add get_densitytensor_to_sampled_expectation_func
- Add  _get_tensor_to_expectation_func
- Refactor get_statetensor_to_expectation_func
- Add relevant tests