### PR TITLE
Add measurement functions for densitytensor

### DIFF
--- a/qujax/__init__.py
+++ b/qujax/__init__.py
@@ -10,13 +10,13 @@ from qujax.circuit_tools import check_unitary
 from qujax.circuit_tools import check_circuit
 from qujax.circuit_tools import print_circuit
 
+from qujax.observable import statetensor_to_densitytensor
 from qujax.observable import statetensor_to_single_expectation
 from qujax.observable import densitytensor_to_single_expectation
 from qujax.observable import get_statetensor_to_expectation_func
 from qujax.observable import get_statetensor_to_sampled_expectation_func
 from qujax.observable import get_densitytensor_to_expectation_func
 from qujax.observable import get_densitytensor_to_sampled_expectation_func
-from qujax.observable import statetensor_to_densitytensor
 from qujax.observable import check_hermitian
 from qujax.observable import integers_to_bitstrings
 from qujax.observable import bitstrings_to_integers

--- a/qujax/__init__.py
+++ b/qujax/__init__.py
@@ -23,6 +23,8 @@ from qujax.density_matrix import _kraus_single
 from qujax.density_matrix import kraus
 from qujax.density_matrix import get_params_to_densitytensor_func
 from qujax.density_matrix import partial_trace
+from qujax.density_matrix import densitytensor_to_measurement_probabilities
+from qujax.density_matrix import densitytensor_to_measured_densitytensor
 
 del version
 del circuit

--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -199,3 +199,50 @@ def get_params_to_densitytensor_func(kraus_ops_seq: Sequence[kraus_op_type],
         return no_params_to_densitytensor_func
 
     return params_to_densitytensor_func
+
+
+def densitytensor_to_measurement_probabilities(densitytensor: jnp.ndarray,
+                                               qubit_inds: Sequence[int]) -> jnp.ndarray:
+    """
+    Extract array of measurement probabilities given a densitytensor and some qubit indices to measure
+    (in the computational basis).
+    I.e. the ith element of the array corresponds to the probability of observing the bitstring
+    represented by the integer i on the measured qubits.
+
+    Args:
+        densitytensor: Input densitytensor.
+        qubit_inds: Sequence of qubit indices to measure.
+
+    Returns:
+        Normalised array of measurement probabilities.
+    """
+    n_qubits = densitytensor.ndim // 2
+    n_qubits_measured = len(qubit_inds)
+    qubit_inds_trace_out = [i for i in range(n_qubits) if i not in qubit_inds]
+    return jnp.diag(partial_trace(densitytensor, qubit_inds_trace_out).reshape(2 * n_qubits_measured,
+                                                                               2 * n_qubits_measured)).real
+
+
+def densitytensor_to_measured_densitytensor(densitytensor: jnp.ndarray,
+                                            qubit_inds: Sequence[int],
+                                            measured_int: int) -> jnp.ndarray:
+    """
+    Returns the post-measurement densitytensor assuming that qubit_inds are measured
+    (in the computational basis) and the bitstring corresponding to integer
+    measured_int is observed.
+
+    Args:
+        densitytensor: Input densitytensor.
+        qubit_inds: Sequence of qubit indices to measure.
+        measured_int: Observed integer.
+
+    Returns:
+        Post-measurement densitytensor (same shape as input densitytensor).
+    """
+    n_qubits = densitytensor.ndim // 2
+    n_qubits_measured = len(qubit_inds)
+    qubit_inds_projector = jnp.diag(jnp.zeros(2 ** n_qubits_measured).at[measured_int].set(1)) \
+        .reshape((2,) * 2 * n_qubits_measured)
+    unnorm_densitytensor = _kraus_single(densitytensor, qubit_inds_projector, qubit_inds)
+    norm_const = jnp.trace(unnorm_densitytensor.reshape(2**n_qubits,  2**n_qubits)).real
+    return unnorm_densitytensor / norm_const

--- a/qujax/density_matrix.py
+++ b/qujax/density_matrix.py
@@ -6,24 +6,9 @@ from jax.lax import scan
 from qujax.circuit import apply_gate, UnionCallableOptionalArray, gate_type
 from qujax.circuit import _to_gate_func, _arrayify_inds, _gate_func_to_unitary
 from qujax.circuit_tools import check_circuit
+from qujax.observable import bitstrings_to_integers
 
 kraus_op_type = Union[gate_type, Iterable[gate_type]]
-
-def statetensor_to_densitytensor(statetensor: jnp.ndarray) -> jnp.ndarray:
-    """
-    Computes a densitytensor representation of a pure quantum state
-    from its statetensor representaton
-
-    Args:
-        statetensor: Input statetensor.
-
-    Returns:
-        A densitytensor representing the quantum state.
-    """
-    n_qubits = statetensor.ndim
-    st = statetensor
-    dt = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2*n_qubits))
-    return dt
 
 
 def _kraus_single(densitytensor: jnp.ndarray,
@@ -241,24 +226,26 @@ def densitytensor_to_measurement_probabilities(densitytensor: jnp.ndarray,
 
 def densitytensor_to_measured_densitytensor(densitytensor: jnp.ndarray,
                                             qubit_inds: Sequence[int],
-                                            measured_int: int) -> jnp.ndarray:
+                                            measurement: Union[int, jnp.ndarray]) -> jnp.ndarray:
     """
     Returns the post-measurement densitytensor assuming that qubit_inds are measured
-    (in the computational basis) and the bitstring corresponding to integer
-    measured_int is observed.
+    (in the computational basis) and the given measurement (integer or bitstring) is observed.
 
     Args:
         densitytensor: Input densitytensor.
         qubit_inds: Sequence of qubit indices to measure.
-        measured_int: Observed integer.
+        measurement: Observed integer or bitstring.
 
     Returns:
         Post-measurement densitytensor (same shape as input densitytensor).
     """
+    measurement = jnp.array(measurement)
+    measured_int = bitstrings_to_integers(measurement) if measurement.ndim == 1 else measurement
+
     n_qubits = densitytensor.ndim // 2
     n_qubits_measured = len(qubit_inds)
     qubit_inds_projector = jnp.diag(jnp.zeros(2 ** n_qubits_measured).at[measured_int].set(1)) \
         .reshape((2,) * 2 * n_qubits_measured)
     unnorm_densitytensor = _kraus_single(densitytensor, qubit_inds_projector, qubit_inds)
-    norm_const = jnp.trace(unnorm_densitytensor.reshape(2**n_qubits,  2**n_qubits)).real
+    norm_const = jnp.trace(unnorm_densitytensor.reshape(2 ** n_qubits, 2 ** n_qubits)).real
     return unnorm_densitytensor / norm_const

--- a/qujax/observable.py
+++ b/qujax/observable.py
@@ -6,7 +6,6 @@ from jax.lax import fori_loop
 
 from qujax.circuit import apply_gate
 from qujax.gates import X, Y, Z
-from qujax.density_matrix import statetensor_to_densitytensor
 
 paulis = {'X': X, 'Y': Y, 'Z': Z}
 
@@ -28,11 +27,12 @@ def densitytensor_to_single_expectation(densitytensor: jnp.ndarray,
     """
     n_qubits = densitytensor.ndim // 2
     dt_indices = 2 * list(range(n_qubits))
-    hermitian_indices = [i + densitytensor.ndim //2 for i in range(hermitian.ndim)]
+    hermitian_indices = [i + densitytensor.ndim // 2 for i in range(hermitian.ndim)]
     for n, q in enumerate(qubit_inds):
         dt_indices[q] = hermitian_indices[n + len(qubit_inds)]
         dt_indices[q + n_qubits] = hermitian_indices[n]
     return jnp.einsum(densitytensor, dt_indices, hermitian, hermitian_indices).real
+
 
 def statetensor_to_single_expectation(statetensor: jnp.ndarray,
                                       hermitian: jnp.ndarray,
@@ -74,7 +74,7 @@ def check_hermitian(hermitian: Union[str, jnp.ndarray]):
 
 
 def get_hermitian_tensor(hermitian_seq: Sequence[Union[str, jnp.ndarray]]) -> jnp.ndarray:
-        """
+    """
         Convert a sequence of observables represented by Pauli strings or Hermitian matrices in tensor form into single array (in tensor form).
 
         Args:
@@ -84,23 +84,23 @@ def get_hermitian_tensor(hermitian_seq: Sequence[Union[str, jnp.ndarray]]) -> jn
             Hermitian matrix in tensor form (array).
 
         """
-        for h in hermitian_seq:
-            check_hermitian(h)
+    for h in hermitian_seq:
+        check_hermitian(h)
 
-        single_arrs = [paulis[h] if isinstance(h, str) else h for h in hermitian_seq]
-        single_arrs = [h_arr.reshape((2,) * int(jnp.log2(h_arr.size))) for h_arr in single_arrs]
+    single_arrs = [paulis[h] if isinstance(h, str) else h for h in hermitian_seq]
+    single_arrs = [h_arr.reshape((2,) * int(jnp.log2(h_arr.size))) for h_arr in single_arrs]
 
-        full_mat = single_arrs[0]
-        for single_matrix in single_arrs[1:]:
-            full_mat = jnp.kron(full_mat, single_matrix)
-        full_mat = full_mat.reshape((2,) * int(jnp.log2(full_mat.size)))
-        return full_mat
+    full_mat = single_arrs[0]
+    for single_matrix in single_arrs[1:]:
+        full_mat = jnp.kron(full_mat, single_matrix)
+    full_mat = full_mat.reshape((2,) * int(jnp.log2(full_mat.size)))
+    return full_mat
 
 
 def _get_tensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
-                                        qubits_seq_seq: Sequence[Sequence[int]],
-                                        coefficients: Union[Sequence[float], jnp.ndarray],
-                                        contraction_function: Callable) \
+                                    qubits_seq_seq: Sequence[Sequence[int]],
+                                    coefficients: Union[Sequence[float], jnp.ndarray],
+                                    contraction_function: Callable) \
         -> Callable[[jnp.ndarray], float]:
     """
     Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
@@ -141,6 +141,7 @@ def _get_tensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[s
 
     return statetensor_to_expectation_func
 
+
 def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
                                         qubits_seq_seq: Sequence[Sequence[int]],
                                         coefficients: Union[Sequence[float], jnp.ndarray]) \
@@ -161,11 +162,13 @@ def get_statetensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Uni
         Function that takes statetensor and returns expected value (float).
     """
 
-    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients, statetensor_to_single_expectation)
+    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients,
+                                           statetensor_to_single_expectation)
+
 
 def get_densitytensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
-                                        qubits_seq_seq: Sequence[Sequence[int]],
-                                        coefficients: Union[Sequence[float], jnp.ndarray]) \
+                                          qubits_seq_seq: Sequence[Sequence[int]],
+                                          coefficients: Union[Sequence[float], jnp.ndarray]) \
         -> Callable[[jnp.ndarray], float]:
     """
     Takes strings (or arrays) representing Hermitian matrices, along with qubit indices and
@@ -183,7 +186,9 @@ def get_densitytensor_to_expectation_func(hermitian_seq_seq: Sequence[Sequence[U
         Function that takes densitytensor and returns expected value (float).
     """
 
-    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients, densitytensor_to_single_expectation)
+    return _get_tensor_to_expectation_func(hermitian_seq_seq, qubits_seq_seq, coefficients,
+                                           densitytensor_to_single_expectation)
+
 
 def get_statetensor_to_sampled_expectation_func(hermitian_seq_seq: Sequence[Sequence[Union[str, jnp.ndarray]]],
                                                 qubits_seq_seq: Sequence[Sequence[int]],
@@ -261,8 +266,8 @@ def get_densitytensor_to_sampled_expectation_func(hermitian_seq_seq: Sequence[Se
                                                                               coefficients)
 
     def densitytensor_to_sampled_expectation_func(statetensor: jnp.ndarray,
-                                                random_key: random.PRNGKeyArray,
-                                                n_samps: int) -> float:
+                                                  random_key: random.PRNGKeyArray,
+                                                  n_samps: int) -> float:
         """
         Maps statetensor to sampled expected value.
 
@@ -358,3 +363,20 @@ def sample_bitstrings(random_key: random.PRNGKeyArray,
 
     """
     return integers_to_bitstrings(sample_integers(random_key, statetensor, n_samps), statetensor.ndim)
+
+
+def statetensor_to_densitytensor(statetensor: jnp.ndarray) -> jnp.ndarray:
+    """
+    Computes a densitytensor representation of a pure quantum state
+    from its statetensor representaton
+
+    Args:
+        statetensor: Input statetensor.
+
+    Returns:
+        A densitytensor representing the quantum state.
+    """
+    n_qubits = statetensor.ndim
+    st = statetensor
+    dt = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2 * n_qubits))
+    return dt

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -246,4 +246,6 @@ def test_measure():
     measured_dt_true = measured_dm.reshape((2,) * 2 * n_qubits)
 
     measured_dt = densitytensor_to_measured_densitytensor(dt, qubit_inds, 0)
+    measured_dt_bits = densitytensor_to_measured_densitytensor(dt, qubit_inds, (0,)*n_qubits)
     assert jnp.allclose(measured_dt_true, measured_dt)
+    assert jnp.allclose(measured_dt_true, measured_dt_bits)

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -3,7 +3,8 @@ from jax import numpy as jnp, jit
 
 import qujax
 from qujax import get_params_to_statetensor_func
-from qujax import _kraus_single, kraus, get_params_to_densitytensor_func, partial_trace, statetensor_to_densitytensor
+from qujax import _kraus_single, kraus, get_params_to_densitytensor_func, partial_trace
+from qujax.observable import statetensor_to_densitytensor
 from qujax import densitytensor_to_measurement_probabilities, densitytensor_to_measured_densitytensor
 
 

--- a/tests/test_density_matrix.py
+++ b/tests/test_density_matrix.py
@@ -1,15 +1,17 @@
+from itertools import combinations
 from jax import numpy as jnp, jit
 
 import qujax
 from qujax import _kraus_single, kraus, get_params_to_densitytensor_func
 from qujax import get_params_to_statetensor_func
 from qujax import partial_trace
+from qujax import densitytensor_to_measurement_probabilities, densitytensor_to_measured_densitytensor
 
 
 def test_kraus_single():
     n_qubits = 3
     dim = 2 ** n_qubits
-    density_matrix = jnp.arange(dim**2).reshape(dim, dim)
+    density_matrix = jnp.arange(dim ** 2).reshape(dim, dim)
     density_tensor = density_matrix.reshape((2,) * 2 * n_qubits)
     kraus_operator = qujax.gates.Rx(0.2)
 
@@ -42,7 +44,7 @@ def test_kraus_single():
 def test_kraus_single_2qubit():
     n_qubits = 4
     dim = 2 ** n_qubits
-    density_matrix = jnp.arange(dim**2).reshape(dim, dim)
+    density_matrix = jnp.arange(dim ** 2).reshape(dim, dim)
     density_tensor = density_matrix.reshape((2,) * 2 * n_qubits)
     kraus_operator_tensor = qujax.gates.ZZPhase(0.1)
     kraus_operator = qujax.gates.ZZPhase(0.1).reshape(4, 4)
@@ -80,7 +82,7 @@ def test_kraus_single_2qubit():
 def test_kraus_multiple():
     n_qubits = 3
     dim = 2 ** n_qubits
-    density_matrix = jnp.arange(dim**2).reshape(dim, dim)
+    density_matrix = jnp.arange(dim ** 2).reshape(dim, dim)
     density_tensor = density_matrix.reshape((2,) * 2 * n_qubits)
 
     kraus_operators = [0.25 * qujax.gates.H, 0.25 * qujax.gates.Rx(0.3), 0.5 * qujax.gates.Ry(0.1)]
@@ -112,16 +114,16 @@ def test_params_to_densitytensor_func():
     param_inds_seq = [(i,) for i in range(n_qubits)]
 
     gate_seq += ["CZ" for _ in range(n_qubits - 1)]
-    qubit_inds_seq += [(i, i+1) for i in range(n_qubits - 1)]
+    qubit_inds_seq += [(i, i + 1) for i in range(n_qubits - 1)]
     param_inds_seq += [() for _ in range(n_qubits - 1)]
 
     params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
     params_to_st = get_params_to_statetensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
 
-    params = jnp.arange(n_qubits)/10.
+    params = jnp.arange(n_qubits) / 10.
 
     st = params_to_st(params)
-    dt_test = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2*n_qubits))
+    dt_test = (st.reshape(-1, 1) @ st.reshape(1, -1).conj()).reshape(2 for _ in range(2 * n_qubits))
 
     dt = params_to_dt(params)
 
@@ -139,7 +141,7 @@ def test_params_to_densitytensor_func_with_bit_flip():
     param_inds_seq = [(i,) for i in range(n_qubits)]
 
     gate_seq += ["CZ" for _ in range(n_qubits - 1)]
-    qubit_inds_seq += [(i, i+1) for i in range(n_qubits - 1)]
+    qubit_inds_seq += [(i, i + 1) for i in range(n_qubits - 1)]
     param_inds_seq += [() for _ in range(n_qubits - 1)]
 
     params_to_pre_bf_st = get_params_to_statetensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
@@ -154,10 +156,10 @@ def test_params_to_densitytensor_func_with_bit_flip():
 
     params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
 
-    params = jnp.arange(n_qubits)/10.
+    params = jnp.arange(n_qubits) / 10.
 
     pre_bf_st = params_to_pre_bf_st(params)
-    pre_bf_dt = (pre_bf_st.reshape(-1, 1) @ pre_bf_st.reshape(1, -1).conj()).reshape(2 for _ in range(2*n_qubits))
+    pre_bf_dt = (pre_bf_st.reshape(-1, 1) @ pre_bf_st.reshape(1, -1).conj()).reshape(2 for _ in range(2 * n_qubits))
     dt_test = kraus(pre_bf_dt, kraus_ops[0], kraus_qubit_inds[0])
 
     dt = params_to_dt(params)
@@ -169,7 +171,7 @@ def test_params_to_densitytensor_func_with_bit_flip():
 
 
 def test_partial_trace_1():
-    state1 = 1/jnp.sqrt(2) * jnp.array([1., 1.])
+    state1 = 1 / jnp.sqrt(2) * jnp.array([1., 1.])
     state2 = jnp.kron(state1, state1)
     state3 = jnp.kron(state1, state2)
 
@@ -180,9 +182,9 @@ def test_partial_trace_1():
     for i in range(3):
         assert jnp.allclose(partial_trace(dt3, [i]), dt2)
 
-    from itertools import combinations
     for i in combinations(range(3), 2):
         assert jnp.allclose(partial_trace(dt3, i), dt1)
+
 
 def test_partial_trace_2():
     n_qubits = 3
@@ -192,15 +194,56 @@ def test_partial_trace_2():
     param_inds_seq = [(i,) for i in range(n_qubits)]
 
     gate_seq += ["CZ" for _ in range(n_qubits - 1)]
-    qubit_inds_seq += [(i, i+1) for i in range(n_qubits - 1)]
+    qubit_inds_seq += [(i, i + 1) for i in range(n_qubits - 1)]
     param_inds_seq += [() for _ in range(n_qubits - 1)]
 
     params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
 
-    params = jnp.arange(1, n_qubits+1)/10.
+    params = jnp.arange(1, n_qubits + 1) / 10.
 
     dt = params_to_dt(params)
     dt_discard_test = jnp.trace(dt, axis1=0, axis2=n_qubits)
     dt_discard = partial_trace(dt, [0])
 
     assert jnp.allclose(dt_discard, dt_discard_test)
+
+
+def test_measure():
+    n_qubits = 3
+
+    gate_seq = ["Rx" for _ in range(n_qubits)]
+    qubit_inds_seq = [(i,) for i in range(n_qubits)]
+    param_inds_seq = [(i,) for i in range(n_qubits)]
+
+    gate_seq += ["CZ" for _ in range(n_qubits - 1)]
+    qubit_inds_seq += [(i, i + 1) for i in range(n_qubits - 1)]
+    param_inds_seq += [() for _ in range(n_qubits - 1)]
+
+    params_to_dt = get_params_to_densitytensor_func(gate_seq, qubit_inds_seq, param_inds_seq, n_qubits)
+
+    params = jnp.arange(1, n_qubits + 1) / 10.
+
+    dt = params_to_dt(params)
+
+    qubit_inds = [0]
+
+    all_probs = jnp.diag(dt.reshape(2 ** n_qubits, 2 ** n_qubits)).real
+    all_probs_marginalise \
+        = all_probs.reshape((2,) * n_qubits).sum(axis=[i for i in range(n_qubits) if i not in qubit_inds])
+
+    probs = densitytensor_to_measurement_probabilities(dt, qubit_inds)
+
+    assert jnp.isclose(probs.sum(), 1.)
+    assert jnp.isclose(all_probs.sum(), 1.)
+    assert jnp.allclose(probs, all_probs_marginalise)
+
+    dm = dt.reshape(2 ** n_qubits, 2 ** n_qubits)
+    projector = jnp.array([[1, 0], [0, 0]])
+    for _ in range(n_qubits - 1):
+        projector = jnp.kron(projector, jnp.eye(2))
+    measured_dm = projector @ dm @ projector.T.conj()
+    measured_dm /= jnp.trace(projector.T.conj() @ projector @ dm)
+    measured_dt_true = measured_dm.reshape((2,) * 2 * n_qubits)
+
+    measured_dt = densitytensor_to_measured_densitytensor(dt, qubit_inds, 0)
+    assert jnp.allclose(measured_dt_true, measured_dt)

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -3,7 +3,7 @@ from jax import numpy as jnp, jit, grad, random, config
 import qujax.gates
 import qujax
 from qujax import densitytensor_to_single_expectation, statetensor_to_single_expectation
-from qujax import statetensor_to_densitytensor
+from qujax.observable import statetensor_to_densitytensor
 
 
 def test_single_expectation():


### PR DESCRIPTION
- Cleaned up the tests (removed some imports etc)
- Added `densitytensor_to_measurement_probabilities` and `densitytensor_to_measured_densitytensor`, these are almost certainly coded suboptimally but I just want to get the API sorted for now