### PR TITLE
Fix CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,12 +35,6 @@ preferred-citation:
   start: 5504
   title: "qujax: Simulating quantum circuits with JAX"
   type: article
-@article{qujax2023,
-  author = {Samuel Duffield, Gabriel Matos and Melf Johannsen},
-  title = {qujax: Simulating quantum circuits with JAX},
-  journal = {Journal of Open Source Software},
-  year = {2023},
-}
   url: "https://joss.theoj.org/papers/10.21105/joss.05504"
   volume: 8
 title: "qujax: Simulating quantum circuits with JAX"


### PR DESCRIPTION
Somehow the `CITATION.cff` ended up being accidentally corrupted, apologies for that. This PR fixes it.