### PR TITLE
Set `titles_only = True` in documentation configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,3 +42,5 @@ autodoc_type_aliases = {
 }
 
 latex_engine = "pdflatex"
+
+titles_only = True


### PR DESCRIPTION
Prevents sidebar navigation from showing function name twice